### PR TITLE
Added FHR and telemetry submission switch.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ browser.safebrowsing.malware.enabled = false
 
 #### Firefox stats collecting
 
-[Submission of stability, performance and usage reports.](https://gecko.readthedocs.org/en/latest/toolkit/components/telemetry/telemetry/preferences.html#data-choices-notification)
+[Submission of stability, performance and usage reports.](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/internals/preferences.html#data-choices-notification)
 
 This is the data submission master kill switch. Data is still locally gathered, unless you disable the services as described below.
 ```

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,13 @@ browser.safebrowsing.malware.enabled = false
 
 #### Firefox stats collecting
 
+[Submission of stability, performance and usage reports.](https://gecko.readthedocs.org/en/latest/toolkit/components/telemetry/telemetry/preferences.html#data-choices-notification)
+
+This is the data submission master kill switch. Data is still locally gathered, unless you disable the services as described below.
+```
+datareporting.policy.dataSubmissionEnabled = false
+```
+
 [Stability and performance reports.](https://www.mozilla.org/en-US/privacy/firefox/#health-report)
 ```
 datareporting.healthreport.service.enabled = false


### PR DESCRIPTION
The `datareporting.policy.dataSubmissionEnabled` disables all FHR and telemetry uploads, won't affect local data gathering (unlike the other options).
